### PR TITLE
Chart remixer Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ index.esm.js
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.vscode

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,11 +28,25 @@ declare namespace VizBldr {
     topojsonConfig?: Record<string, D3plusConfig> | ((level: OlapClient.Level) => D3plusConfig);
     translations?: Record<string, Translation>;
     userConfig?: D3plusConfig;
+    chartLimits: Optional<ChartLimits>;
   }
 
   type Formatter = (value: number) => string;
 
   type D3plusConfig = {[key: string]: any};
+
+  interface ChartLimits {
+    /** Maximum number of bars in barchart */
+    MAX_BARS: number;
+    /** Minimum number of data points in groupto render a line in lineplot */
+    LINE_POINT_MIN: number;
+    /** Max number of lines to render in lineplot */
+    LINE_MAX: number;
+    /** Max shapes to render in stacked chart */
+    STACKED_SHAPE_MAX: number;
+    /** Max number of shapes to render in tree map */
+    TREE_MAP_SHAPE_MAX: number;
+  }
 
   type ChartType =
     | "barchart"

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,11 +16,13 @@ declare namespace VizBldr {
 
   interface VizbuilderProps {
     allowedChartTypes?: ChartType[];
+    chartLimits?: Optional<ChartLimits>;
     className?: string;
     datacap?: number;
     defaultLocale?: string;
     downloadFormats?: string[];
     measureConfig?: Record<string, D3plusConfig> | ((measure: OlapClient.Measure) => D3plusConfig);
+    nonIdealState?: React.ComponentType,
     onPeriodChange?: (period: Date) => void;
     queries: QueryResult | QueryResult[];
     showConfidenceInt?: boolean;
@@ -28,7 +30,6 @@ declare namespace VizBldr {
     topojsonConfig?: Record<string, D3plusConfig> | ((level: OlapClient.Level) => D3plusConfig);
     translations?: Record<string, Translation>;
     userConfig?: D3plusConfig;
-    chartLimits: Optional<ChartLimits>;
   }
 
   type Formatter = (value: number) => string;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "^7.0.0",
-    "@datawheel/olap-client": "^2.0.0-beta.1",
+    "@datawheel/olap-client": "^2.0.0-beta.3",
     "@datawheel/use-translation": "^0.1.0",
     "classnames": "^2.0.0",
     "d3plus-common": "^1.0.0",

--- a/src/components/NonIdealState.jsx
+++ b/src/components/NonIdealState.jsx
@@ -1,15 +1,10 @@
 import React from "react";
 
-const NonIdealState = props => 
+const NonIdealState = () => 
 <div className="vizbuilder-nonidealstate">
-  {props.nonIdealStateImg && <img className="vizbuilder-nonidealstate-img" src={props.nonIdealStateImg}/>}
   <h1 className="vizbuilder-nonidealstate-header">
-    {props.nonIdealStateHeaderText || "No results"}
+    {"No results"}
   </h1>
-  {props.nonIdealStateSubtitleText && 
-    <p className="vizbuilder-nonidealstate-subtitle">
-      {props.nonIdealStateSubtitleText}
-    </p>
   }
 </div>;
 

--- a/src/components/NonIdealState.jsx
+++ b/src/components/NonIdealState.jsx
@@ -1,11 +1,14 @@
 import React from "react";
+import {useTranslation} from "../toolbox/useTranslation";
 
-const NonIdealState = () => 
-<div className="vizbuilder-nonidealstate">
-  <h1 className="vizbuilder-nonidealstate-header">
-    {"No results"}
-  </h1>
-  }
-</div>;
+const NonIdealState = () => {
+  const {translate: t} = useTranslation();
+
+  return <div className="vizbuilder-nonidealstate">
+    <h1 className="vizbuilder-nonidealstate-header">
+      {t("nonidealstate_msg")}
+    </h1>
+  </div>;
+}
 
 export default NonIdealState;

--- a/src/components/NonIdealState.jsx
+++ b/src/components/NonIdealState.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+const NonIdealState = props => 
+<div className="vizbuilder-nonidealstate">
+  {props.nonIdealStateImg && <img className="vizbuilder-nonidealstate-img" src={props.nonIdealStateImg}/>}
+  <h1 className="vizbuilder-nonidealstate-header">
+    {props.nonIdealStateHeaderText || "No results"}
+  </h1>
+  {props.nonIdealStateSubtitleText && 
+    <p className="vizbuilder-nonidealstate-subtitle">
+      {props.nonIdealStateSubtitleText}
+    </p>
+  }
+</div>;
+
+export default NonIdealState;

--- a/src/components/Vizbuilder.jsx
+++ b/src/components/Vizbuilder.jsx
@@ -41,7 +41,7 @@ export const Vizbuilder = props => {
       );
 
       // return NonIdealState comp if the list of available chart types is empty
-      return chartCards.length > 0 ? chartCards : <NonIdealState/>;
+      return chartCards.length > 0 ? chartCards : props.nonIdealState || <NonIdealState/>;
   }, [currentChart, currentPeriod, charts, props.showConfidenceInt]);
 
   useEffect(() => {

--- a/src/components/Vizbuilder.jsx
+++ b/src/components/Vizbuilder.jsx
@@ -4,6 +4,7 @@ import {normalizeMeasureConfig, resizeEnsureHandler, scrollEnsureHandler} from "
 import {useCharts} from "../toolbox/useCharts";
 import {TranslationProvider} from "../toolbox/useTranslation";
 import {ChartCard} from "./ChartCard";
+import NonIdealState from "./NonIdealState";
 
 /** @type {React.FC<VizBldr.VizbuilderProps>} */
 export const Vizbuilder = props => {
@@ -20,7 +21,7 @@ export const Vizbuilder = props => {
     const isSingleChart = currentChart !== "" && charts.length > 1;
     const measureConfig = normalizeMeasureConfig(props.measureConfig);
 
-    return charts
+    const chartCards = charts
       .filter(chart => chart && (currentChart ? chart.key === currentChart : true))
       .map(chart =>
         <ChartCard
@@ -38,6 +39,9 @@ export const Vizbuilder = props => {
           userConfig={props.userConfig}
         />
       );
+
+      // return NonIdealState comp if the list of available chart types is empty
+      return chartCards.length > 0 ? chartCards : <NonIdealState/>;
   }, [currentChart, currentPeriod, charts, props.showConfidenceInt]);
 
   useEffect(() => {

--- a/src/toolbox/chartConfigs.js
+++ b/src/toolbox/chartConfigs.js
@@ -315,15 +315,17 @@ const makeConfig = {
     const {timeDrilldown: timeLevel} = dg;
     const {formatter, measure} = chart.measureSet;
 
-    const levelName = levels[0].caption;
+    const levelName = levels[0]?.caption;
     const measureName = measure.name;
     const timeLevelName = timeLevel ? getColumnId(timeLevel.caption, dg.dataset) : levelName;
+    // group by a static string if there are no other dimensions besides time
+    const groupBy = levels?.length ? levels.map(lvl => lvl.caption) : () => "ALL";
 
     const config = assign(
       {
         confidence: false,
         discrete: "x",
-        groupBy: levels.map(lvl => lvl.caption),
+        groupBy,
         x: timeLevelName,
         xConfig: {
           title: timeLevel?.caption
@@ -465,7 +467,7 @@ function tooltipGenerator(chart, {translate: t}) {
   const {measure, collection, source, moe, uci, lci, formatter} = measureSet;
 
   const measureName = measure.name;
-  const firstLevelName = levels[0].name;
+  const firstLevelName = levels[0]?.name;
 
   const collectionName = collection ? collection.name : "";
   const lciName = lci ? lci.name : "";

--- a/src/toolbox/chartLimits.js
+++ b/src/toolbox/chartLimits.js
@@ -1,0 +1,11 @@
+/**
+ * Parameters for determining the constraints and limits of certain chart types
+ * @type {VizBldr.ChartLimits}
+ */
+export const DEFAULT_CHART_LIMITS = {
+  MAX_BARS: 20,
+  LINE_POINT_MIN: 2,
+  LINE_MAX: 20,
+  STACKED_SHAPE_MAX: 200,
+  TREE_MAP_SHAPE_MAX: 1000
+};

--- a/src/toolbox/charts.js
+++ b/src/toolbox/charts.js
@@ -292,14 +292,21 @@ const remixerForChartType = {
       });
     }
 
+    // get list of all non-time drilldowns -- a Chart will be created for each
+    let otherDrilldowns =
+      (dg.stdDrilldowns || []).concat((dg.geoDrilldown ? [dg.geoDrilldown] : []))
+      .filter(lvl => dg.membersCount[lvl.caption] <= 20);
+
+    // TODO - figure out how to show a line plot with no other drilldown levels
+
     return flatMap(dg.measureSets, measureSet =>
-      dg.stdDrilldowns.map(level => {
+      otherDrilldowns.map(level => {
         const levels = [level];
         return {
           chartType: CT.LINEPLOT,
           dg,
           isMap: isGeographicLevel(level),
-          isTimeline: isTimeLevel(level),
+          isTimeline: false, // time level is plotted on x-axis in line plot
           key: keyMaker(dg.dataset, levels, measureSet, CT.LINEPLOT),
           levels,
           measureSet

--- a/src/toolbox/charts.js
+++ b/src/toolbox/charts.js
@@ -2,7 +2,7 @@ import flatMap from "lodash/flatMap";
 import flattenDeep from "lodash/flattenDeep";
 import includes from "lodash/includes";
 import range from "lodash/range";
-import VizBldr from "../..";
+
 import {
   getPermutations,
   permutationIterator

--- a/src/toolbox/charts.js
+++ b/src/toolbox/charts.js
@@ -292,16 +292,16 @@ const remixerForChartType = {
       });
     }
 
-    // get list of all non-time drilldowns -- a Chart will be created for each
+    // get list of all non-time drilldowns (geo + standard) with less than 20 members
     let otherDrilldowns =
       (dg.stdDrilldowns || []).concat((dg.geoDrilldown ? [dg.geoDrilldown] : []))
       .filter(lvl => dg.membersCount[lvl.caption] <= 20);
 
-    // TODO - figure out how to show a line plot with no other drilldown levels
-
+    // for each measure...
     return flatMap(dg.measureSets, measureSet =>
-      otherDrilldowns.map(level => {
-        const levels = [level];
+      // if other drilldowns exist, create one for each
+      (otherDrilldowns.length > 0 ? otherDrilldowns : [false]).map(level => {
+        const levels = level ? [level] : [];
         return {
           chartType: CT.LINEPLOT,
           dg,

--- a/src/toolbox/charts.js
+++ b/src/toolbox/charts.js
@@ -229,7 +229,7 @@ const remixerForChartType = {
       isMap: true,
       isTimeline: !!dg.timeDrilldown,
       key: keyMaker(dg.dataset, drilldowns, measureSet, CT.GEOMAP),
-      drilldowns,
+      levels: drilldowns,
       measureSet
     }));  
   },

--- a/src/toolbox/datagroup.js
+++ b/src/toolbox/datagroup.js
@@ -52,7 +52,7 @@ export function buildDatagroup(qr, props) {
 
   const topojsonConfig = geoDrilldown ? getTopojsonConfig(geoDrilldown) : undefined;
 
-  const stdDrilldowns = drilldowns.filter(lvl => !isTimeLevel(lvl));
+  const stdDrilldowns = drilldowns.filter(lvl => !isTimeLevel(lvl) && !isGeographicLevel(lvl));
 
   const drilldownNames = drilldowns.map(lvl => lvl.caption);
   const {members, membersCount} = buildMemberMap(dataset, drilldownNames);

--- a/src/toolbox/parse.js
+++ b/src/toolbox/parse.js
@@ -6,6 +6,7 @@
  */
 export function parseDate(dateString) {
   // dateString is quarter, in format `2010Q2` or `10Q2`
+  dateString = dateString?.toString() || "";
   const maybeQuarter = dateString.match(/(\d{2,4})(Q\d)/i);
   if (maybeQuarter) {
     const [, year, quarter] = maybeQuarter;

--- a/src/toolbox/title.js
+++ b/src/toolbox/title.js
@@ -68,6 +68,10 @@ export function chartTitleGenerator(chart, {currentChart, currentPeriod}) {
     }
   }
 
+  if (title[title.length - 1] === ",") {
+    return title.slice(0, -1)
+  }
+
   return title;
 }
 

--- a/src/toolbox/useCharts.js
+++ b/src/toolbox/useCharts.js
@@ -3,6 +3,7 @@ import flatMap from "lodash/flatMap";
 import {useEffect, useMemo, useState} from "react";
 import {chartComponents} from "../components/ChartCard";
 import {asArray} from "./array";
+import {DEFAULT_CHART_LIMITS} from "./chartLimits";
 import {chartRemixer} from "./charts";
 import {buildDatagroup} from "./datagroup";
 import {findHigherCurrentPeriod} from "./find";
@@ -19,6 +20,8 @@ export const useCharts = props => {
     getDefaultPeriod(props.queries)
   );
 
+  const chartLimits = {...DEFAULT_CHART_LIMITS, ...(props.chartLimits || {})};
+
   const charts = useMemo(() => {
     const allowedChartTypes = props.allowedChartTypes || Object.keys(chartComponents);
     const datagroupProps = {
@@ -27,9 +30,9 @@ export const useCharts = props => {
     };
     return flatMap(asArray(props.queries), query => {
       const datagroup = buildDatagroup(query, datagroupProps);
-      return flatMap(allowedChartTypes, chartType => chartRemixer(datagroup, chartType));
+      return flatMap(allowedChartTypes, chartType => chartRemixer(datagroup, chartType, chartLimits));
     });
-  }, [props.queries]);
+  }, [props.queries, props.chartLimits]);
 
   useEffect(() => {
     const defaultPeriod = getDefaultPeriod(props.queries);

--- a/src/toolbox/useCharts.js
+++ b/src/toolbox/useCharts.js
@@ -20,14 +20,15 @@ export const useCharts = props => {
     getDefaultPeriod(props.queries)
   );
 
-  const chartLimits = {...DEFAULT_CHART_LIMITS, ...(props.chartLimits || {})};
-
+  
   const charts = useMemo(() => {
     const allowedChartTypes = props.allowedChartTypes || Object.keys(chartComponents);
     const datagroupProps = {
       datacap: props.datacap || 20000,
       getTopojsonConfig: normalizeTopojsonConfig(props.topojsonConfig)
     };
+    const chartLimits = {...DEFAULT_CHART_LIMITS, ...(props.chartLimits || {})};
+
     return flatMap(asArray(props.queries), query => {
       const datagroup = buildDatagroup(query, datagroupProps);
       return flatMap(allowedChartTypes, chartType => chartRemixer(datagroup, chartType, chartLimits));

--- a/src/toolbox/useTranslation.js
+++ b/src/toolbox/useTranslation.js
@@ -18,6 +18,7 @@ const LOCALE_EN = {
     message: "Error details: \"{message}\".",
     title: "Title: "
   },
+  nonidealstate_msg: "No results",
   sentence_connectors: {
     all_words: ", ",
     two_words: " and ",

--- a/src/toolbox/validation.js
+++ b/src/toolbox/validation.js
@@ -16,7 +16,7 @@ export function areKindaNumeric(list, tolerance = 0.8) {
  * @returns {boolean}
  */
 export function isGeographicLevel(level) {
-  return level.dimension.dimensionType === DimensionType.Geographic;
+  return level?.dimension?.dimensionType === DimensionType.Geographic;
 }
 
 /**
@@ -44,5 +44,5 @@ export function isNumeric(n) {
  * @returns {boolean}
  */
 export function isTimeLevel(level) {
-  return level.dimension.dimensionType === DimensionType.Time;
+  return level?.dimension?.dimensionType === DimensionType.Time;
 }


### PR DESCRIPTION
Adds to the chart remixer logic to allow for more valid cases where geomap and lineplots are shown.

Adds a NonIdealState to show in case of no rendered charts

Improves chart remixer documentation with added comments and some simplified logic

Adds ChartLimits user prop for overriding default chart logic thresholds

Removes top ten logic from lineplot (at request of @davelandry)