### PR TITLE
Title Generator Improvements

### DIFF
--- a/src/components/ChartCard.jsx
+++ b/src/components/ChartCard.jsx
@@ -40,6 +40,7 @@ export const ChartCard = props => {
   const {
     chart,
     currentChart,
+    currentPeriod,
     isSingleChart,
     isUniqueChart
   } = props;
@@ -52,7 +53,7 @@ export const ChartCard = props => {
 
   const config = useMemo(() => createChartConfig(chart, {
     currentChart,
-    currentPeriod: props.currentPeriod,
+    currentPeriod,
     isSingleChart,
     isUniqueChart,
     locale,
@@ -61,7 +62,7 @@ export const ChartCard = props => {
     showConfidenceInt: Boolean(props.showConfidenceInt),
     translate,
     userConfig: props.userConfig || {}
-  }), [isSingleChart, isUniqueChart, locale]);
+  }), [isSingleChart, isUniqueChart, locale, currentPeriod]);
 
   console.log(chart.chartType, config);
 

--- a/src/components/ChartCard.jsx
+++ b/src/components/ChartCard.jsx
@@ -40,7 +40,6 @@ export const ChartCard = props => {
   const {
     chart,
     currentChart,
-    currentPeriod,
     isSingleChart,
     isUniqueChart
   } = props;
@@ -53,16 +52,14 @@ export const ChartCard = props => {
 
   const config = useMemo(() => createChartConfig(chart, {
     currentChart,
-    currentPeriod,
     isSingleChart,
     isUniqueChart,
     locale,
     measureConfig: props.measureConfig,
-    onPeriodChange: props.onPeriodChange,
     showConfidenceInt: Boolean(props.showConfidenceInt),
     translate,
     userConfig: props.userConfig || {}
-  }), [isSingleChart, isUniqueChart, locale, currentPeriod]);
+  }), [isSingleChart, isUniqueChart, locale]);
 
   console.log(chart.chartType, config);
 

--- a/src/components/ChartCard.jsx
+++ b/src/components/ChartCard.jsx
@@ -61,8 +61,6 @@ export const ChartCard = props => {
     userConfig: props.userConfig || {}
   }), [isSingleChart, isUniqueChart, locale]);
 
-  console.log(chart.chartType, config);
-
   const saveChart = useCallback(format => {
     const chartInstance = nodeRef.current;
     if (chartInstance) {

--- a/src/components/ChartCard.jsx
+++ b/src/components/ChartCard.jsx
@@ -67,9 +67,16 @@ export const ChartCard = props => {
     const chartInstance = nodeRef.current;
     if (chartInstance) {
       const svgElement = chartInstance.container.querySelector("svg");
-      const filename = config.title
-        .replace(/[^\w]/g, "_")
-        .replace(/[_]+/g, "_");
+
+      const filename = ((config.title instanceof Function)
+        // If title is a Function, it means that the title is dependent upon the filtered data.
+        // Because d3plus handles this generation internally, we need to generate title again using the viz's
+        // internal '_filteredData' variable as its param
+        ? config.title(chartInstance.viz._filteredData)
+        : config.title)
+          // and replace special characters with underscores
+          .replace(/[^\w]/g, "_")
+          .replace(/[_]+/g, "_");
 
       const getBackground = node => {
         if (node.nodeType !== Node.ELEMENT_NODE) return "white";

--- a/src/components/ChartCard.jsx
+++ b/src/components/ChartCard.jsx
@@ -63,6 +63,8 @@ export const ChartCard = props => {
     userConfig: props.userConfig || {}
   }), [isSingleChart, isUniqueChart, locale]);
 
+  console.log(chart.chartType, config);
+
   const saveChart = useCallback(format => {
     const chartInstance = nodeRef.current;
     if (chartInstance) {

--- a/src/toolbox/chartConfigs.js
+++ b/src/toolbox/chartConfigs.js
@@ -74,7 +74,7 @@ export function createChartConfig(chart, uiParams) {
     config.total = measureName;
   }
 
-  if (timeDrilldown && config.time && !includes(["lineplot", "stacked"], chartType)) {
+  if (timeDrilldown && config.time && chart.isTimeline) {
     config.timeline = isEnlarged;
   }
 
@@ -91,7 +91,7 @@ export function createChartConfig(chart, uiParams) {
       return [datum[timeDrilldown.caption] || "", datum[timeDrilldownId] || ""];
     };
 
-    if (currentPeriod[1]) {
+    if (currentPeriod?.[1]) {
       const isBetweenPeriods = isBetween.bind(
         null,
         parseDate(currentPeriod[0]).valueOf() - 1,
@@ -99,7 +99,7 @@ export function createChartConfig(chart, uiParams) {
       );
       config.timeFilter = d => isBetweenPeriods(parseDate(d[timeDrilldownId]).valueOf());
     }
-    else if (currentPeriod[0]) {
+    else if (currentPeriod?.[0]) {
       // eslint-disable-next-line eqeqeq
       config.timeFilter = d => currentPeriod[0] == d[timeDrilldownId];
     }

--- a/src/toolbox/chartConfigs.js
+++ b/src/toolbox/chartConfigs.js
@@ -11,12 +11,10 @@ import {chartTitleGenerator} from "./title";
 /**
  * @typedef UIParams
  * @property {string} currentChart
- * @property {[string, string]} currentPeriod
  * @property {boolean} isSingleChart
  * @property {boolean} isUniqueChart
  * @property {string} locale
  * @property {(measure: import("@datawheel/olap-client").Measure) => VizBldr.D3plusConfig} measureConfig
- * @property {(periodLeft: string, periodRight?: string) => void} [onPeriodChange]
  * @property {boolean} showConfidenceInt
  * @property {import("@datawheel/use-translation").TranslateFunction} translate
  * @property {VizBldr.D3plusConfig} userConfig
@@ -40,26 +38,16 @@ export function createChartConfig(chart, uiParams) {
   const config = assign(
     {
       legend: false,
-      duration: 0,
 
       total: false,
       totalFormat: d => `Total: ${formatter(d)}`,
 
-      xConfig: {
-        duration: 0
-        // title: null
-      },
       yConfig: {
-        duration: 0,
         title: measureName,
         tickFormat: formatter
       },
       label: labelFunctionGenerator(...levelNames),
       locale: uiParams.locale,
-
-      shapeConfig: {
-        duration: 0
-      },
 
       sum: measureName,
       value: measureName
@@ -79,42 +67,8 @@ export function createChartConfig(chart, uiParams) {
   }
 
   if (timeDrilldown && config.timeline) {
-    const {currentPeriod, onPeriodChange} = uiParams;
-    const timeDrilldownId = getColumnId(timeDrilldown.caption, dg.dataset);
-    const epochReference = keyBy(dg.dataset, d => parseDate(d[timeDrilldownId]).valueOf());
-
-    /** @type {(date: Date | number) => [string, string]} */
-    const getPeriodForDate = date => {
-      const epoch = date.valueOf();
-      const tzOffset = new Date(epoch).getTimezoneOffset() * 60000;
-      const datum = epochReference[epoch] || epochReference[epoch + tzOffset] || {};
-      return [datum[timeDrilldown.caption] || "", datum[timeDrilldownId] || ""];
-    };
-
-    if (currentPeriod?.[1]) {
-      const isBetweenPeriods = isBetween.bind(
-        null,
-        parseDate(currentPeriod[0]).valueOf() - 1,
-        parseDate(currentPeriod[1]).valueOf() + 1
-      );
-      config.timeFilter = d => isBetweenPeriods(parseDate(d[timeDrilldownId]).valueOf());
-    }
-    else if (currentPeriod?.[0]) {
-      // eslint-disable-next-line eqeqeq
-      config.timeFilter = d => currentPeriod[0] == d[timeDrilldownId];
-    }
-
     config.timelineConfig = {
-      brushing: false,
-      on: {
-        end: !onPeriodChange
-          ? undefined
-          : date => {
-            const [periodLeft, periodRight = []] = asArray(date).map(getPeriodForDate);
-            periodLeft && onPeriodChange(periodLeft[1], periodRight[1]);
-          }
-      },
-      tickFormat: date => getPeriodForDate(date)[0] || ""
+      brushing: false
     };
   }
 

--- a/src/toolbox/chartConfigs.js
+++ b/src/toolbox/chartConfigs.js
@@ -372,6 +372,10 @@ const makeConfig = {
       config.time = getColumnId(timeLevel.caption, dg.dataset);
     }
 
+    // TODO - add ability to control this threshold value
+    config.threshold = 0.005;
+    config.thresholdName = firstLevel.caption;
+
     return config;
   }
 };

--- a/src/toolbox/charts.js
+++ b/src/toolbox/charts.js
@@ -221,12 +221,10 @@ const remixerForChartType = {
     const kValues = range(1, multipleMemberLevels.length + 1);
     return flatMap(allowedMeasures, measureSet =>
       flatMap(kValues, k =>
-        // get different combinations of non-time (discrete) drilldowns
         Array.from(permutationIterator(multipleMemberLevels, k), levels => ({
           chartType: CT.DONUT,
           dg,
           isMap: false,
-          // timeline is only possible if time drilldown is present and the chartType does not include a time axis already
           isTimeline: !!dg.timeDrilldown,
           key: keyMaker(dg.dataset, levels, measureSet, CT.DONUT),
           levels,

--- a/src/toolbox/charts.js
+++ b/src/toolbox/charts.js
@@ -406,7 +406,6 @@ const remixerForChartType = {
     const {dataset, membersCount, members, timeDrilldown} = dg;
     const chartType = CT.TREEMAP;
 
-    // const nonTimeDrilldowns = getNonTimeDrilldowns(dg);
     const nonTimeDrilldowns = getNonTimeDrilldowns(dg);
 
     /* DISABLE IF... */

--- a/src/toolbox/charts.js
+++ b/src/toolbox/charts.js
@@ -40,7 +40,7 @@ const getNonTimeDrilldowns = dg => dg.drilldowns.filter(lvl => !isTimeLevel(lvl)
  * @param {VizBldr.Struct.Datagroup} dg 
  * @returns {import("@datawheel/olap-client").Level[]} List of combined non-geo levels
  */
- const getNonGeoDrilldowns = dg => dg.drilldowns.filter(lvl => !isGeographicLevel(lvl));
+const getNonGeoDrilldowns = dg => dg.drilldowns.filter(lvl => !isGeographicLevel(lvl));
 
 /**
  * Generates a unique key based on the parameters set for a chart.

--- a/src/toolbox/charts.js
+++ b/src/toolbox/charts.js
@@ -271,7 +271,7 @@ const remixerForChartType = {
       isMap: true,
       isTimeline: !!dg.timeDrilldown,
       key: keyMaker(dg.dataset, drilldowns, measureSet, CT.GEOMAP),
-      levels: drilldowns,
+      levels: getNonTimeDrilldowns(dg),
       measureSet
     }));  
   },

--- a/src/toolbox/find.js
+++ b/src/toolbox/find.js
@@ -12,24 +12,6 @@ export function findFirstNumber(string, elseValue) {
 }
 
 /**
- * Returns the value of the highest timeLevel value in the dataset,
- * but lower or equal than the current time.
- * @param {string[]} timelist An array with time-related members
- */
-export function findHigherCurrentPeriod(timelist) {
-  const currentTime = new Date().getTime();
-  const matchIndex = timelist.reduce((selected, item, index, list) => {
-    const itemValue = parseDate(item).getTime();
-    if (itemValue <= currentTime) {
-      const selectedValue = new Date(list[selected] || -8640000000000000).getTime();
-      return Math.max(itemValue, selectedValue) === itemValue ? index : selected;
-    }
-    return selected;
-  }, -1);
-  return matchIndex > -1 ? timelist[matchIndex] : timelist[0];
-}
-
-/**
  * @param {import("@datawheel/olap-client").Cube} cube
  * @param {VizBldr.Struct.MeasureItem} item
  * @returns {VizBldr.Struct.MeasureSet | undefined}

--- a/src/toolbox/find.js
+++ b/src/toolbox/find.js
@@ -41,3 +41,27 @@ export function findMeasuresInCube({measuresByName}, item) {
     };
   }
 }
+
+const getDisplayTime = (d, timeLevelId, timeLevelName) => d?.hasOwnProperty(timeLevelName) ? d[timeLevelName] : d?.[timeLevelId];
+
+/**
+ * Finds the min and max time properties of an array of data objects
+ * @param {object[]} data - data to search
+ * @param {string} timeLevelId - property name of time field to compare
+ * @param {string} timeLevelName - name of time level to return (if it exists) to make for a better display name than the ID
+ * @returns {minTime: string, maxTime: string} - the display strings of the min and max time fields
+ */
+export function findTimeRange(data, timeLevelId, timeLevelName) {
+  if (!(data && data.length && timeLevelId)) return {min: null, max: null};
+
+  const out = data.reduce((acc, d) => {
+    if (d[timeLevelId] < acc.min[timeLevelId]) acc.min = d;
+    if (d[timeLevelId] > acc.max[timeLevelId]) acc.max = d;
+    return acc;
+  }, {max: data[0], min: data[0]});
+
+  return {
+    minTime: getDisplayTime(out.min, timeLevelId, timeLevelName).toString(),
+    maxTime: getDisplayTime(out.max, timeLevelId, timeLevelName).toString()
+  };
+}

--- a/src/toolbox/title.js
+++ b/src/toolbox/title.js
@@ -1,8 +1,39 @@
+import { AggregatorType } from "@datawheel/olap-client";
 import { findTimeRange } from "./find";
 import { getColumnId } from "./strings";
 
 /**
+ * Human-readable names of special aggregator types.
+ * Needed to make certain types of measures more explicit about their measure's derivation.
+ * 
+ * If an aggregation type needs clarification beyond measure name, insert it here.
+ */
+const SPECIAL_AGGREGATOR_QUALIFIERS = {
+  [AggregatorType.AVG]: "Average",
+  [AggregatorType.MAX]: "Max",
+  [AggregatorType.MIN]: "Min"
+};
+
+/**
  * Returns a common title string from a list of parameters.
+ * ---------------------------------------------------------
+ * Examples of title variations:
+ * 
+ * Standard drilldowns with no cuts:
+ * _MEASURE_NAME by DRILLDOWN_1 and DRILLDOWN_2_
+ * 
+ * Special aggregation type (e.g. average):
+ * _AGGREGATOR_TYPE_NAME MEASURE_NAME by DRILLDOWN_
+ * 
+ * Chart with single drilldown of type "time" used to filter data using "timeline" feature:
+ * _MEASURE_NAME Over Time_
+ * 
+ * Chart with time drilldown plotted on axis:
+ * _MEASURE_NAME by DRILLDOWN (TIME_LEVEL_NAME: CURRENT_PERIOD)_
+ * 
+ * Chart with cuts applied _on levels not included in drilldowns/levels_: 
+ * _MEASURE_NAME of Selected CUT_LEVEL_NAME Members by DRILLDOWN_1_
+ * 
  * @param {VizBldr.Struct.Chart} chart
  * @param {object} options
  */
@@ -11,49 +42,51 @@ export function chartTitleGenerator(chart, options) {
   const {dg, measureSet} = chart;
   const {members} = dg;
 
-  const measureName = measureSet.measure.name;
+  let title;
 
-  const cuts = [];
+  // FIRST, add measure (with appropriate qualifiers) to the start of the title
+  title = `${getAggregationTypeQualifier(measureSet.measure.aggregatorType)}${measureSet.measure.name}`;
 
-  const allLevels = [...chart.levels];
-  const allLevelNames = allLevels.map(obj => obj.name);
-  const allCutNames = [...dg.cuts.keys()];
+  /** Set of cut level names, to be filtered to include only levels not accounted for in drilldowns */
+  const allCutNames = new Set(dg.cuts.keys());
+  /** List of Level names to include in CUT clause */
+  const cutLabels = [];
+  /** Labels of drilldowns with only a single member */
+  const singleMemberDrilldownLabels = [];
 
-  let n = allLevels.length;
-  while (n--) {
-    const level = allLevels[n];
-    const levelName = level.caption;
-    const values = members[levelName];
+  /** List of Dimension names to be shown as  */
+  const drilldownNames = chart.levels
+    .map(lvl => lvl.caption)
+    .filter(levelName => {
+      const values = members[levelName];
+      // if there is only one dimension of a drilldown dimension...
+      if (values.length === 1) {
+        // don't show it as a selected cut
+        if (allCutNames.has(levelName)) allCutNames.delete(levelName);
+        // but show it as a separate label
+        const label = `${levelName}: ${values[0]}`;
+        singleMemberDrilldownLabels.unshift(label);
+        return false;
+      }
+      else if (allCutNames.has(levelName)) allCutNames.delete(levelName);
+      return true;
+    });
 
-    let label;
-    // if level has one member, remove from level list and add as cut
-    if (values.length === 1) {
-      label = `${levelName}: ${values[0]}`;
-      const levelIndex = allLevelNames.indexOf(levelName);
-      if (levelIndex > -1) allLevelNames.splice(levelIndex, 1);
-      const cutIndex = allCutNames.indexOf(levelName);
-      if (levelIndex > -1) allCutNames.splice(cutIndex, 1);
-      cuts.unshift(label);
-    }
-  }
+  // if time drilldown exists but it is not included in Chart.levels but there is a cut on it, add to cut level list
+  if (dg.timeDrilldown?.caption && allCutNames.has(dg.timeDrilldown.caption)) allCutNames.delete(dg.timeDrilldown.caption);
+  cutLabels.unshift(...allCutNames.values());
 
-  allCutNames.forEach(cutLvlName => {
-    const numMembers = dg.cuts.get(cutLvlName)?.length;
-    if (!allLevelNames.includes(cutLvlName)) {
-      let label = `${cutLvlName}: ${numMembers} Selected`
-      cuts.unshift(label);
-    }
-  });
+  // add labels for cut levels not included in Chart.levels
+  if (cutLabels.length > 0) title += ` of Selected ${arrayToSentence(cutLabels)} Members`;
 
-  let title = measureName;
+  // add labels for levels with single member
+  if (singleMemberDrilldownLabels.length > 0) title += ` (${singleMemberDrilldownLabels.join(", ")})`;
 
-  if (cuts.length > 0) title += ` (${arrayToSentence(cuts)})`;
-
-  // add levels / dimensions to titles
-  if (allLevelNames.length > 0) {
+  // add levels with multiple members to titles
+  if (drilldownNames.length > 0) {
     title += chart.isTopTen
-      ? ` for top ${arrayToSentence(allLevelNames)}`
-      : ` by ${arrayToSentence(allLevelNames)}`;
+      ? ` for top ${arrayToSentence(drilldownNames)}`
+      : ` by ${arrayToSentence(drilldownNames)}`;
   }
 
   let titleFn = null;
@@ -76,10 +109,6 @@ export function chartTitleGenerator(chart, options) {
     }
     // else, if time is shown on one axis, say "Over Time"
     else title += ` Over Time`;
-  }
-
-  if (title[title.length - 1] === ",") {
-    return title.slice(0, -1)
   }
 
   return titleFn || title;
@@ -105,6 +134,17 @@ function arrayToSentence(strings, options = {}) {
     return [bulk.join(allWords), last].join(lastWord);
   }
   return strings.join("");
+}
+
+/**
+ * Returns a string giving a few qualifying words (if necessary) to add to a measure in the case
+ * that a measure does not have a self-evident aggregation method (like sum)
+ * @param {import("@datawheel/olap-client").AggregatorType} aggregationType - 
+ * @returns 
+ */
+function getAggregationTypeQualifier(aggregationType) {
+  const qualifier = SPECIAL_AGGREGATOR_QUALIFIERS[aggregationType];
+  return qualifier ? `${qualifier} ` : "";
 }
 
 /**

--- a/src/toolbox/title.js
+++ b/src/toolbox/title.js
@@ -1,3 +1,4 @@
+import { findTimeRange } from "./find";
 import { getColumnId } from "./strings";
 
 /**
@@ -61,10 +62,8 @@ export function chartTitleGenerator(chart, options) {
     else if (chart.isTimeline) {
       // add current period to title (because it should be the only period being shown)
       titleFn = data => {
-        const allTimeValues = [...data.map(d => d[timeLevelId])];
-        const minYear = Math.min(...allTimeValues);
-        const maxYear = Math.max(...allTimeValues);
-        return `${title} (${timeLevelName}: ${periodToString(minYear, maxYear !== minYear && maxYear)})`;
+        const {minTime, maxTime} = findTimeRange(data, timeLevelId, timeLevelName);
+        return `${title} (${timeLevelName}: ${periodToString(minTime, maxTime !== minTime && maxTime)})`;
       }
     } else {
       title += ` Over Time`;

--- a/src/toolbox/title.js
+++ b/src/toolbox/title.js
@@ -7,7 +7,7 @@
  */
 export function chartTitleGenerator(chart, {currentPeriod}) {
 
-  console.log("Chart", chart.chartType, chart);
+  console.log("Chart title", chart.chartType, chart);
 
   const {dg, measureSet} = chart;
   const {members} = dg;
@@ -58,7 +58,7 @@ export function chartTitleGenerator(chart, {currentPeriod}) {
       // add current period to title (because it should be the only period being shown)
       title += ` (${dg.timeDrilldown.caption}: ${periodToString(currentPeriod)})`;
     } else {
-      title += ` over Time`;
+      title += ` Over Time`;
     }
   }
   

--- a/src/toolbox/useCharts.js
+++ b/src/toolbox/useCharts.js
@@ -84,5 +84,6 @@ function calculateDefaultPeriod(query) {
   });
 
   // Return lowest common period
-  return periodSet.sort()[0];
+  
+  return periodSet.sort()[periodSet.length - 1];
 }

--- a/src/toolbox/useCharts.js
+++ b/src/toolbox/useCharts.js
@@ -1,25 +1,17 @@
-import {Cube} from "@datawheel/olap-client";
 import flatMap from "lodash/flatMap";
-import {useEffect, useMemo, useState} from "react";
+import {useMemo, useState} from "react";
 import {chartComponents} from "../components/ChartCard";
 import {asArray} from "./array";
 import {DEFAULT_CHART_LIMITS} from "./chartLimits";
 import {chartRemixer} from "./charts";
 import {buildDatagroup} from "./datagroup";
-import {findHigherCurrentPeriod} from "./find";
 import {normalizeTopojsonConfig} from "./props";
-import {getColumnId} from "./strings";
-import {isMatchingLevel, isTimeLevel} from "./validation";
 
 /**
  * @param {VizBldr.VizbuilderProps} props
  */
 export const useCharts = props => {
   const [currentChart, setCurrentChart] = useState("");
-  const [currentPeriod, setCurrentPeriod] = useState(() =>
-    getDefaultPeriod(props.queries)
-  );
-
   
   const charts = useMemo(() => {
     const allowedChartTypes = props.allowedChartTypes || Object.keys(chartComponents);
@@ -35,55 +27,5 @@ export const useCharts = props => {
     });
   }, [props.queries, props.chartLimits]);
 
-  useEffect(() => {
-    const defaultPeriod = getDefaultPeriod(props.queries);
-    setCurrentPeriod(defaultPeriod);
-  }, [props.queries]);
-
-  return {currentChart, setCurrentChart, currentPeriod, setCurrentPeriod, charts};
+  return {currentChart, setCurrentChart, charts};
 };
-
-/**
- * Picks the default period from an external query.
- * @param {VizBldr.QueryResult | VizBldr.QueryResult[]} queries
- * @returns {[string, string]}
- */
-function getDefaultPeriod(queries) {
-  const defaultPeriods = asArray(queries).map(calculateDefaultPeriod);
-  const defaultPeriodsUnique = [...new Set(defaultPeriods)].filter(Boolean);
-  const firstDefaultPeriod = defaultPeriodsUnique[0] || "";
-  return [firstDefaultPeriod, ""];
-}
-
-/**
- * @param {VizBldr.QueryResult} query
- * @returns {string}
- */
-function calculateDefaultPeriod(query) {
-  const cube = new Cube(query.cube);
-  const {drilldowns, measures} = query.params;
-
-  const timeLevel = Array.from(cube.levelIterator)
-    .find(level =>
-      drilldowns.some(drilldown => isTimeLevel(level) && isMatchingLevel(drilldown, level))
-    );
-
-  // Bail if the query doesn't have a time dimension
-  if (!timeLevel) return "";
-
-  const captionId = getColumnId(timeLevel.caption, query.dataset);
-
-  const periodSet = measures.map(({measure}) => {
-    const timeMembers = new Set(
-      // Prevent empty charts by getting only time members where
-      // the measure has an useful value
-      // eslint-disable-next-line eqeqeq
-      query.dataset.filter(d => d[measure] != 0).map(d => ''.concat(d[captionId]))
-    );
-    return findHigherCurrentPeriod([...timeMembers]);
-  });
-
-  // Return lowest common period
-  
-  return periodSet.sort()[periodSet.length - 1];
-}


### PR DESCRIPTION
Improve the logic and syntax of title generation and remove the state tracking of `currentPeriod` outside the d3plus charts.

Changes in PR include:
- added comments to title generation function to make logic clearer
- refactored title generation logic to allow for clearer meaning and less ambiguity
- removal of `currentPeriod` and setter in Vizbuilder state to allow for a cleaner control flow (as requested by Dave)
- add ability for title to be a Function in cases where the timeline feature is used so that graphs (whether in the UI or when exported) have the current time period in the title
- adds d3plus `duration` properties back in (Dave request)
- adds more consistent use of `isTimeline` Chart property in chart remixer logic
- refactors some chart remixers to only include time drilldown in Chart.levels if the chart type is "time-native" (ie does not use timeline feature)