### PR TITLE
Improve Time Axis Tick Formatting

### DIFF
--- a/src/toolbox/chartConfigs.js
+++ b/src/toolbox/chartConfigs.js
@@ -257,7 +257,7 @@ const makeConfig = {
 
     const levelName = levels[0]?.caption;
     const measureName = measure.name;
-    const timeLevelName = timeLevel ? getColumnId(timeLevel.caption, dg.dataset) : levelName;
+    const timeLevelName = timeLevel?.caption;
     // group by a static string if there are no other dimensions besides time
     const groupBy = levels?.length ? levels.map(lvl => lvl.caption) : () => "ALL";
 

--- a/src/toolbox/find.js
+++ b/src/toolbox/find.js
@@ -1,5 +1,4 @@
 import {formatAbbreviate} from "d3plus-format";
-import {parseDate} from "./parse";
 
 /**
  * Returns the first number it finds in a `string`, else returns `elseValue`.


### PR DESCRIPTION
Add small tweak so that, for graphs like the line plot at stacked chart, the caption of a time level is used as the `time` d3plus config property instead of the time level ID.  This takes advantage of recent d3plus tick formatting improvements for quarter formatting.

Also removes unused function.

Tested on years, months, quarters, and days. ✅ 