### PR TITLE
Chart Title Localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,10 +214,10 @@ For ease of development, this package also exports [a helper function `buildQuer
 
 ### `interface Translation`
 
-An object whose keys are message keys, and its values the localized string to show in the interface.
+An object whose keys are message keys, and its values the localized string to show in the interface. See `src/toolbox/useTranslation.js` for an example of the defaults and how they are used.
 
 ```ts
-interface Translation {
+    interface Translation extends I18N.TranslationDict {
   /* These are actions shown in buttons in the UI */
   "action_close": string;
   "action_enlarge": string;
@@ -238,6 +238,23 @@ interface Translation {
     "message": string;
     "title": string;
   };
+  /* Message for the default NonIdealState when no charts are valid for queries */ 
+  "nonidealstate_msg"?: string;
+  /* For listing words */
+  "sentence_connectors": {
+    "all_words": string;
+    "two_words": string;
+    "last_word": string;
+  };
+  /* Sentence fragments for dynamically constructing chart titles (see example for use)*/
+  "title": {
+    "of_selected_cut_members": string;
+    "top_drilldowns": string;
+    "by_drilldowns": string;
+    "over_time": string;
+    "measure_and_modifier": string;
+  }
+}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -214,45 +214,53 @@ For ease of development, this package also exports [a helper function `buildQuer
 
 ### `interface Translation`
 
-An object whose keys are message keys, and its values the localized string to show in the interface. See `src/toolbox/useTranslation.js` for an example of the defaults and how they are used.
+An object whose keys are message keys, and its values the localized string to show in the interface. Here is an example of a `Translation` object and how it should be used.
 
 ```ts
-    interface Translation extends I18N.TranslationDict {
+const translation: Translation = {
   /* These are actions shown in buttons in the UI */
-  "action_close": string;
-  "action_enlarge": string;
-  "action_retry": string;
-  "action_fileissue": string;
-
+  action_close: "Close",
+  action_download: "Download {{format}}",
+  action_enlarge: "Enlarge",
+  action_fileissue: "File an issue",
+  action_retry: "Retry",
+  aggregators: {
+    avg: "Average",
+    max: "Max",
+    min: "Min"
+  },
+  
   /* These labels are shown in the charts tooltip */
-  "chart_labels": {
-    "ci": string;
-    "collection": string;
-    "moe": string;
-    "source": string;
-  };
+  chart_labels: {
+    ci: "Confidence Interval",
+    moe: "Margin of Error",
+    source: "Source",
+    collection: "Collection"
+  },
 
   /* These labels are shown in the suggested error message when filing a new issue */
-  "error": {
-    "detail": string;
-    "message": string;
-    "title": string;
-  };
+  error: {
+    detail: "",
+    message: "Error details: \"{{message}}\".",
+    title: "Title: "
+  },
+
   /* Message for the default NonIdealState when no charts are valid for queries */ 
-  "nonidealstate_msg"?: string;
+  nonidealstate_msg: "No results",
+
   /* For listing words */
-  "sentence_connectors": {
-    "and": string;
-  };
+  sentence_connectors: {
+    and: "and"
+  },
+
   /* Sentence fragments for dynamically constructing chart titles (see example for use)*/
-  "title": {
-    "of_selected_cut_members": string;
-    "top_drilldowns": string;
-    "by_drilldowns": string;
-    "over_time": string;
-    "measure_and_modifier": string;
+  title: {
+    of_selected_cut_members: "of Selected {{members}} Members",
+    top_drilldowns: "for Top {{drilldowns}}",
+    by_drilldowns: "by {{drilldowns}}",
+    over_time: "Over Time",
+    measure_and_modifier: "{{modifier}} {{measure}}"
   }
-}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -242,9 +242,7 @@ An object whose keys are message keys, and its values the localized string to sh
   "nonidealstate_msg"?: string;
   /* For listing words */
   "sentence_connectors": {
-    "all_words": string;
-    "two_words": string;
-    "last_word": string;
+    "and": string;
   };
   /* Sentence fragments for dynamically constructing chart titles (see example for use)*/
   "title": {

--- a/index.d.ts
+++ b/index.d.ts
@@ -87,6 +87,11 @@ declare namespace VizBldr {
     "action_enlarge": string;
     "action_retry": string;
     "action_fileissue": string;
+    "aggregators": {
+      "avg": string,
+      "max": string,
+      "min": string
+    };
     "chart_labels": {
       "ci": string;
       "collection": string;
@@ -98,11 +103,19 @@ declare namespace VizBldr {
       "message": string;
       "title": string;
     };
+    "nonidealstate_msg"?: string;
     "sentence_connectors": {
       "all_words": string;
       "two_words": string;
       "last_word": string;
     };
+    "title": {
+      "of_selected_cut_members": string;
+      "top_drilldowns": string;
+      "by_drilldowns": string;
+      "over_time": string;
+      "measure_and_modifier": string;
+    }
   }
 
   namespace Struct {

--- a/index.d.ts
+++ b/index.d.ts
@@ -105,9 +105,7 @@ declare namespace VizBldr {
     };
     "nonidealstate_msg"?: string;
     "sentence_connectors": {
-      "all_words": string;
-      "two_words": string;
-      "last_word": string;
+      "and": string;
     };
     "title": {
       "of_selected_cut_members": string;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@babel/runtime-corejs3": "^7.0.0",
     "@datawheel/olap-client": "^2.0.0-beta.3",
-    "@datawheel/use-translation": "^0.1.0",
+    "@datawheel/use-translation": "^0.1.3",
     "classnames": "^2.0.0",
     "d3plus-common": "^1.0.0",
     "d3plus-export": "^1.0.0",

--- a/src/components/Vizbuilder.jsx
+++ b/src/components/Vizbuilder.jsx
@@ -40,8 +40,8 @@ export const Vizbuilder = props => {
         />
       );
 
-      // return NonIdealState comp if the list of available chart types is empty
-      return chartCards.length > 0 ? chartCards : props.nonIdealState || <NonIdealState/>;
+    // return NonIdealState comp if the list of available chart types is empty
+    return chartCards.length > 0 ? chartCards : props.nonIdealState || <NonIdealState/>;
   }, [currentChart, currentPeriod, charts, props.showConfidenceInt]);
 
   useEffect(() => {

--- a/src/toolbox/chartConfigs.js
+++ b/src/toolbox/chartConfigs.js
@@ -62,7 +62,7 @@ export function createChartConfig(chart, uiParams) {
   config.zoom = chartType === "geomap" && isSingleChart;
 
   if (config.title === undefined) {
-    config.title = chartTitleGenerator(chart, uiParams);
+    config.title = chartTitleGenerator(chart, uiParams.translate);
   }
 
   assign(config, uiParams.measureConfig[measureName] || {});

--- a/src/toolbox/title.js
+++ b/src/toolbox/title.js
@@ -32,7 +32,10 @@ export function chartTitleGenerator(chart, translate) {
   let title;
 
   // FIRST, add measure (with appropriate qualifiers) to the start of the title
-  title = `${getAggregationTypeQualifier(measureSet.measure.aggregatorType, translate)}${measureSet.measure.name}`;
+  title = translate("title.measure_and_modifier", {
+    modifier: getAggregationTypeQualifier(measureSet.measure.aggregatorType, translate),
+    measure: measureSet.measure.name
+  }).trim(); // remove starting or trailing whitespaces
 
   /** Set of cut level names, to be filtered to include only levels not accounted for in drilldowns */
   const allCutNames = new Set(dg.cuts.keys());
@@ -128,7 +131,7 @@ function arrayToSentence(strings, translate) {
  */
 function getAggregationTypeQualifier(aggregationType, translate) {
   const qualifier = aggregationType && typeof aggregationType === "string" && translate(`aggregators.${aggregationType.toLowerCase()}`);
-  return qualifier && !qualifier.startsWith("aggregators.") ? `${qualifier} ` : "";
+  return qualifier && !qualifier.startsWith("aggregators.") ? qualifier : "";
 }
 
 /**

--- a/src/toolbox/title.js
+++ b/src/toolbox/title.js
@@ -112,12 +112,12 @@ export function chartTitleGenerator(chart, translate) {
 function arrayToSentence(strings, translate) {
   strings = strings.filter(Boolean);
   if (strings.length === 2) {
-    return strings.join(translate("sentence_connectors.two_words"));
+    return strings.join(` ${translate("sentence_connectors.and")} `);
   }
   if (strings.length > 1) {
     const bulk = strings.slice();
     const last = bulk.pop();
-    return [bulk.join(translate("sentence_connectors.all_words")), last].join(translate("sentence_connectors.last_word"));
+    return [bulk.join(", "), last].join(` ${translate("sentence_connectors.and")} `);
   }
   return strings.join("");
 }

--- a/src/toolbox/useTranslation.js
+++ b/src/toolbox/useTranslation.js
@@ -3,7 +3,7 @@ import {translationFactory} from "@datawheel/use-translation";
 /** @type {VizBldr.Translation} */
 const LOCALE_EN = {
   action_close: "Close",
-  action_download: "Download {format}",
+  action_download: "Download {{format}}",
   action_enlarge: "Enlarge",
   action_fileissue: "File an issue",
   action_retry: "Retry",
@@ -20,7 +20,7 @@ const LOCALE_EN = {
   },
   error: {
     detail: "",
-    message: "Error details: \"{message}\".",
+    message: "Error details: \"{{message}}\".",
     title: "Title: "
   },
   nonidealstate_msg: "No results",
@@ -28,11 +28,11 @@ const LOCALE_EN = {
     and: "and"
   },
   title: {
-    of_selected_cut_members: "of Selected {members} Members",
-    top_drilldowns: "for Top {drilldowns}",
-    by_drilldowns: "by {drilldowns}",
+    of_selected_cut_members: "of Selected {{members}} Members",
+    top_drilldowns: "for Top {{drilldowns}}",
+    by_drilldowns: "by {{drilldowns}}",
     over_time: "Over Time",
-    measure_and_modifier: "{modifier} {measure}"
+    measure_and_modifier: "{{modifier}} {{measure}}"
   }
 };
 

--- a/src/toolbox/useTranslation.js
+++ b/src/toolbox/useTranslation.js
@@ -7,6 +7,11 @@ const LOCALE_EN = {
   action_enlarge: "Enlarge",
   action_fileissue: "File an issue",
   action_retry: "Retry",
+  aggregators: {
+    avg: "Average",
+    max: "Max",
+    min: "Min"
+  },
   chart_labels: {
     ci: "Confidence Interval",
     moe: "Margin of Error",
@@ -23,6 +28,12 @@ const LOCALE_EN = {
     all_words: ", ",
     two_words: " and ",
     last_word: ", and "
+  },
+  title: {
+    of_selected_cut_members: "of Selected {members} Members",
+    top_drilldowns: "for Top {drilldowns}",
+    by_drilldowns: "by {drilldowns}",
+    over_time: "Over Time"
   }
 };
 

--- a/src/toolbox/useTranslation.js
+++ b/src/toolbox/useTranslation.js
@@ -25,15 +25,14 @@ const LOCALE_EN = {
   },
   nonidealstate_msg: "No results",
   sentence_connectors: {
-    all_words: ", ",
-    two_words: " and ",
-    last_word: ", and "
+    and: "and"
   },
   title: {
     of_selected_cut_members: "of Selected {members} Members",
     top_drilldowns: "for Top {drilldowns}",
     by_drilldowns: "by {drilldowns}",
-    over_time: "Over Time"
+    over_time: "Over Time",
+    measure_and_modifier: "{modifier} {measure}"
   }
 };
 


### PR DESCRIPTION
Adds localization logic into the chart title generation function so that charts can be more fully translated.

Changes include:
- edited `Translation` type to include new keys
- added default sentence fragments for default english locale
- updated README to account for changes to the `Translation` interface