### PR TITLE
UI tweaks/fixes/improvements

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -29,7 +29,17 @@ function Demo() {
       {result && <Vizwrapper
         queries={result}
         downloadFormats={["svg", "png"]}
-        allowedChartTypes={["barchart", "barchartyear", "geomap", "lineplot", "stacked", "treemap"]}
+        allowedChartTypes={[
+          "barchart",
+          "barchartyear",
+          "donut",
+          "geomap",
+          "histogram",
+          "lineplot",
+          "pie",
+          "stacked",
+          "treemap"
+        ]}
       />}
     </Flex>
   );

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,7 @@ declare namespace VizBldr {
       "by_drilldowns": string;
       "over_time": string;
       "measure_and_modifier": string;
+      "total": string;
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@datawheel/use-translation": "^0.2.0",
         "@mantine/core": "^6.0.0",
         "@tabler/icons-react": "^2.22.0",
-        "classnames": "^2.0.0",
+        "clsx": "^1.2.1",
         "d3plus-common": "^1.2.4",
         "d3plus-export": "^1.3.0",
         "d3plus-format": "^1.2.4",
@@ -25,7 +25,6 @@
         "@vitejs/plugin-react": "^3.1.0",
         "eslint": "^7.25.0",
         "eslint-plugin-react": "^7.23.2",
-        "prop-types": "^15.8.0",
         "query-string": "^7.1.1",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
@@ -34,8 +33,6 @@
         "vite": "^4.1.4"
       },
       "peerDependencies": {
-        "@mantine/core": "^6.0.0",
-        "prop-types": "^15.8.0",
         "react": "^16.12.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.12.0 || ^17.0.0 || ^18.0.0"
       }
@@ -1095,6 +1092,14 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/@mantine/styles/node_modules/clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@mantine/styles/node_modules/csstype": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
@@ -1752,15 +1757,10 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
-    },
     "node_modules/clsx": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "engines": {
         "node": ">=6"
       }
@@ -6609,6 +6609,11 @@
         "csstype": "3.0.9"
       },
       "dependencies": {
+        "clsx": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+          "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+        },
         "csstype": {
           "version": "3.0.9",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
@@ -7078,15 +7083,10 @@
         "readdirp": "~3.6.0"
       }
     },
-    "classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
-    },
     "clsx": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
     },
     "color-convert": {
       "version": "1.9.3",

--- a/src/components/ChartCard.jsx
+++ b/src/components/ChartCard.jsx
@@ -88,16 +88,12 @@ export const ChartCard = props => {
   const buttonText = focused ? translate("action_close") : translate("action_enlarge");
   const buttonVariant = focused ? "filled" : "light";
   const height = focused ? "calc(100vh - 3rem)" : isSingleChart ? "75vh" : 300;
-  const buttonPosition = focused || isSingleChart ? "static" : "absolute";
 
   return (
-    <Box className="vb-chart-card" h={height} miw={200} w="100%" style={{overflow: "hidden"}}>
+    <Box className="vb-chart-card" h={height} w="100%" style={{overflow: "hidden"}}>
       <ErrorBoundary>
         <Stack spacing={0} h={height} style={{position: "relative"}} w="100%">
-          <Box style={{flex: "1 1 100%"}} className="vb-chart-viz" ref={nodeRef} p="xs">
-            <ChartComponent config={config} />
-          </Box>
-          <Group className="vb-chart-toolbar" position="right" p="xs" spacing="xs" align="center" bottom={0} right={0} style={{position: buttonPosition}}>
+          <Group className="vb-chart-toolbar" position="right" p="xs" spacing="xs" align="center">
             {(focused || isSingleChart) && props.downloadFormats && <DownloadButton
               formats={props.downloadFormats}
               onClick={saveChart}
@@ -114,6 +110,9 @@ export const ChartCard = props => {
               </Button>
             }
           </Group>
+          <Box style={{flex: "1 1 auto"}} className="vb-chart-viz" ref={nodeRef} pb="xs" px="xs">
+            <ChartComponent config={config} />
+          </Box>
         </Stack>
       </ErrorBoundary>
     </Box>

--- a/src/components/Vizdebugger.jsx
+++ b/src/components/Vizdebugger.jsx
@@ -1,4 +1,4 @@
-import cls from "classnames";
+import cls from "clsx";
 import React, {useEffect, useMemo, useState} from "react";
 import {ObjectInspector} from "react-inspector";
 import {normalizeMeasureConfig} from "../toolbox/props";

--- a/src/toolbox/chartConfigs.js
+++ b/src/toolbox/chartConfigs.js
@@ -116,7 +116,7 @@ const makeConfig = {
         .filter(lvl => lvl.caption in dg.dataset[0])
         .concat(levels)
         .map(lvl => lvl.caption);
-      config.time = getColumnId(timeLevel.caption, dg.dataset);
+      config.time = timeLevel.caption;
     }
     else if (levels.length > 1) {
       config.groupBy = levels.map(lvl => lvl.caption);
@@ -188,7 +188,7 @@ const makeConfig = {
     );
 
     if (timeLevel) {
-      config.time = getColumnId(timeLevel.caption, dg.dataset);
+      config.time = timeLevel.caption;
     }
 
     return config;
@@ -232,7 +232,7 @@ const makeConfig = {
     }
 
     if (timeLevel) {
-      config.time = getColumnId(timeLevel.caption, dg.dataset);
+      config.time = timeLevel.caption;
     }
 
     return config;
@@ -357,7 +357,7 @@ const makeConfig = {
     );
 
     if (timeLevel) {
-      config.time = getColumnId(timeLevel.caption, dg.dataset);
+      config.time = timeLevel.caption;
     }
 
     // TODO - add ability to control this threshold value

--- a/src/toolbox/chartConfigs.js
+++ b/src/toolbox/chartConfigs.js
@@ -126,7 +126,7 @@ const makeConfig = {
   /**
    * - chart.dg.timeDrilldown is always defined here, checked on the previous step
    */
-  barchartyear(chart, uiParams) {
+  barchartyear(chart, uiParams, isEnlarged) {
     const {levels, dg} = chart;
     const {timeDrilldown: timeLevel} = dg;
     const {formatter, measure} = chart.measureSet;
@@ -134,13 +134,14 @@ const makeConfig = {
 
     const firstLevelName = firstLevel.caption;
     const measureName = measure.name;
-    const timeLevelName = timeLevel
-      ? getColumnId(timeLevel.caption, dg.dataset)
-      : firstLevelName;
+    const timeLevelName = timeLevel ? timeLevel.caption : firstLevelName;
 
     const config = assign(
       {
         discrete: "x",
+        groupPadding: isEnlarged ? 5 : 1,
+        time: timeLevelName,
+        timeline: false,
         x: timeLevelName,
         xConfig: {
           title: timeLevel ? getCaption(timeLevel, dg.locale) : null
@@ -155,9 +156,6 @@ const makeConfig = {
       },
       uiParams.userConfig
     );
-
-    delete config.time;
-    delete config.total;
 
     return config;
   },

--- a/src/toolbox/chartConfigs.js
+++ b/src/toolbox/chartConfigs.js
@@ -11,6 +11,7 @@ import {tooltipGenerator} from "./tooltip";
  * @param {VizBldr.UIParams} uiParams
  */
 export function createChartConfig(chart, uiParams) {
+  const {translate: t} = uiParams;
   const {chartType, dg, measureSet, levels} = chart;
   const {timeDrilldown, locale} = dg;
   const {formatter, measure} = measureSet;
@@ -30,7 +31,7 @@ export function createChartConfig(chart, uiParams) {
       tooltipConfig: tooltipGenerator(chart, uiParams),
 
       total: false,
-      totalFormat: d => `Total: ${formatter(d)}`,
+      totalFormat: d => `${t("title.total")}: ${formatter(d)}`,
 
       yConfig: {
         title: getCaption(measure, locale),

--- a/src/toolbox/chartConfigs.js
+++ b/src/toolbox/chartConfigs.js
@@ -24,7 +24,7 @@ export function createChartConfig(chart, uiParams) {
 
   const config = assign(
     {
-      legend: false,
+      legend: isEnlarged || isSingleChart,
 
       titlePadding: isEnlarged || isSingleChart,
 

--- a/src/toolbox/chartConfigs.js
+++ b/src/toolbox/chartConfigs.js
@@ -25,14 +25,6 @@ export function createChartConfig(chart, uiParams) {
     {
       legend: false,
 
-      timelineConfig: {
-        brushing: false,
-        padding: 0
-      },
-
-      titleConfig: {
-        padding: 0
-      },
       titlePadding: isEnlarged || isSingleChart,
 
       tooltipConfig: tooltipGenerator(chart, uiParams),
@@ -44,6 +36,7 @@ export function createChartConfig(chart, uiParams) {
         title: getCaption(measure, locale),
         tickFormat: formatter
       },
+
       label: labelFunctionGenerator(...levelNames),
       locale,
 

--- a/src/toolbox/useTranslation.js
+++ b/src/toolbox/useTranslation.js
@@ -31,7 +31,8 @@ const LOCALE_EN = {
     top_drilldowns: "for Top {{drilldowns}}",
     by_drilldowns: "by {{drilldowns}}",
     over_time: "Over Time",
-    measure_and_modifier: "{{modifier}} {{measure}}"
+    measure_and_modifier: "{{modifier}} {{measure}}",
+    total: "Total"
   }
 };
 


### PR DESCRIPTION
 - uses timeLevel value instead of ID for "time" config (more reliable for Quarter formatting)
 - enables all chart types for example/index
 - removes overly opinionated timeline and title configs
 - adds title "total" to `VizBldr.Translation`
 - fixes overlapping `ChartCard` UI
 - enables chart legends when large
 - fixes `barchartyear` time settings (internal d3plus behavior is able to handle things better now)
 - fixes module import for `clsx` in example app
 - fixes `package-lock.json` (was giving me an error when trying to `npm ci`)
