### PR TITLE
vizbuilder locale fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ declare namespace VizBldr {
     userConfig?: D3plusConfig;
   }
 
-  type Formatter = (value: number) => string;
+  type Formatter = (value: number, locale: string) => string;
 
   type D3plusConfig = {[key: string]: any};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2231,19 +2231,19 @@
       }
     },
     "node_modules/d3plus-axis": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/d3plus-axis/-/d3plus-axis-1.2.8.tgz",
-      "integrity": "sha512-4eMbDuxdQIo9InWJdW4DHpbcBICWiZlKxYlabOOAbRJP5YfUZIJVlkUm8BgIM99MwxsNNrKg0M27Rmi73qT1qA==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/d3plus-axis/-/d3plus-axis-1.2.10.tgz",
+      "integrity": "sha512-EzpUyT95w6UOfNd0v4wEIXWCm56IpL1WJftNpprhC+d8lDYsZ0/l/nBFvBMyiv3ckfmaURy+G+aSUokjdUSUZQ==",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-scale": "^4.0.2",
         "d3-selection": "^3.0.0",
         "d3-transition": "^3.0.1",
         "d3plus-color": "^1.1.2",
         "d3plus-common": "^1.2.4",
         "d3plus-format": "^1.2.4",
-        "d3plus-shape": "^1.1.0",
-        "d3plus-text": "^1.2.2"
+        "d3plus-shape": "^1.1.1",
+        "d3plus-text": "^1.2.3"
       }
     },
     "node_modules/d3plus-color": {
@@ -2277,9 +2277,9 @@
       }
     },
     "node_modules/d3plus-format": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3plus-format/-/d3plus-format-1.2.4.tgz",
-      "integrity": "sha512-3KelOUaridcP/G9ii3Faw9sj9FmoqixtWh/PtUWuZ3tJ9sfl52wj7UHnDbfDoFLpcZB3oPg15FDPljocGknhsA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/d3plus-format/-/d3plus-format-1.2.6.tgz",
+      "integrity": "sha512-m/d5cv5uRj3MObj1nZhrTeUxA8gu/IIUoMKVsSbwVJS0qoqm8s1u68JV/oW3aL3j48avASJoDpK0mxSmJjwZtQ==",
       "dependencies": {
         "d3-format": "^3.1.0",
         "d3-time": "^3.1.0",
@@ -2365,21 +2365,21 @@
       }
     },
     "node_modules/d3plus-plot": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3plus-plot/-/d3plus-plot-1.2.4.tgz",
-      "integrity": "sha512-VAS+4lwkW01P7O+9Zfp7xESyEQ4WxADvqjWAwCfAQJapx9DIbe8BL6a6xqXwCDMVq8Yr57BzUaC2y1+8i3fJPA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/d3plus-plot/-/d3plus-plot-1.2.7.tgz",
+      "integrity": "sha512-1jfavVBwL3YeMbt48/tO07HIXZC9SuiznzSOKAxEZCuGYWVVvQgK+tRvAkIS6D8qUTmr8pZUwmoMBdJq/uj0QQ==",
       "dependencies": {
-        "d3-array": "^3.2.3",
+        "d3-array": "^3.2.4",
         "d3-collection": "^1.0.7",
         "d3-scale": "^4.0.2",
         "d3-selection": "^3.0.0",
         "d3-shape": "^3.2.0",
-        "d3plus-axis": "^1.2.8",
+        "d3plus-axis": "^1.2.10",
         "d3plus-color": "^1.1.2",
         "d3plus-common": "^1.2.4",
-        "d3plus-format": "^1.2.4",
+        "d3plus-format": "^1.2.6",
         "d3plus-shape": "^1.1.1",
-        "d3plus-viz": "^1.3.2"
+        "d3plus-viz": "^1.3.4"
       }
     },
     "node_modules/d3plus-priestley": {
@@ -2445,13 +2445,13 @@
       }
     },
     "node_modules/d3plus-timeline": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/d3plus-timeline/-/d3plus-timeline-1.1.2.tgz",
-      "integrity": "sha512-VG+pD18QpYDOBLmVJ06RCPg/Bl30xIfMUsiZYIx3BdQftGsDeDavkVIYrNkInwRzKZv1WE4wZVfJD9XKn7dK1g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3plus-timeline/-/d3plus-timeline-1.1.4.tgz",
+      "integrity": "sha512-6l4efJqM96PaJYV3csSQ38mXwz1A7ItAVPwhHs0a6gs/w7zstfyu/TlDi9XVgPML4Yg3Rp+yZ6NVDXgkVtUNhA==",
       "dependencies": {
         "d3-brush": "^3.0.0",
         "d3-selection": "^3.0.0",
-        "d3plus-axis": "^1.2.8",
+        "d3plus-axis": "^1.2.9",
         "d3plus-color": "^1.1.2",
         "d3plus-common": "^1.2.4",
         "d3plus-format": "^1.2.4"
@@ -2469,24 +2469,24 @@
       }
     },
     "node_modules/d3plus-viz": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/d3plus-viz/-/d3plus-viz-1.3.3.tgz",
-      "integrity": "sha512-hipd3SwSVwdXmE3hcBDbdogbJzo84kawgeqqXow077tEC0J8ZUCmV5EqBBnuZIYJEIfipAYC3TcfkZuKS1pvWQ==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/d3plus-viz/-/d3plus-viz-1.3.5.tgz",
+      "integrity": "sha512-U5cLkwRre8/4+pcxto+tAGpHpBAp9AH9EVi7+CXJ+Kwq3YYdvH1NU4I21dr7PzlUcy5xB3yd7sfdeUEE+XvuUQ==",
       "dependencies": {
-        "d3-array": "^3.2.3",
+        "d3-array": "^3.2.4",
         "d3-brush": "^3.0.0",
         "d3-color": "^3.1.0",
         "d3-queue": "^3.0.7",
         "d3-request": "^1.0.6",
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0",
-        "d3plus-axis": "^1.2.5",
+        "d3plus-axis": "^1.2.10",
         "d3plus-color": "^1.1.2",
         "d3plus-common": "^1.2.4",
-        "d3plus-format": "^1.2.4",
+        "d3plus-format": "^1.2.6",
         "d3plus-legend": "^1.2.1",
         "d3plus-text": "^1.2.3",
-        "d3plus-timeline": "^1.1.0",
+        "d3plus-timeline": "^1.1.4",
         "d3plus-tooltip": "^1.1.1",
         "lrucache": "^1.0.3"
       }
@@ -7462,19 +7462,19 @@
       }
     },
     "d3plus-axis": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/d3plus-axis/-/d3plus-axis-1.2.8.tgz",
-      "integrity": "sha512-4eMbDuxdQIo9InWJdW4DHpbcBICWiZlKxYlabOOAbRJP5YfUZIJVlkUm8BgIM99MwxsNNrKg0M27Rmi73qT1qA==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/d3plus-axis/-/d3plus-axis-1.2.10.tgz",
+      "integrity": "sha512-EzpUyT95w6UOfNd0v4wEIXWCm56IpL1WJftNpprhC+d8lDYsZ0/l/nBFvBMyiv3ckfmaURy+G+aSUokjdUSUZQ==",
       "requires": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-scale": "^4.0.2",
         "d3-selection": "^3.0.0",
         "d3-transition": "^3.0.1",
         "d3plus-color": "^1.1.2",
         "d3plus-common": "^1.2.4",
         "d3plus-format": "^1.2.4",
-        "d3plus-shape": "^1.1.0",
-        "d3plus-text": "^1.2.2"
+        "d3plus-shape": "^1.1.1",
+        "d3plus-text": "^1.2.3"
       }
     },
     "d3plus-color": {
@@ -7508,9 +7508,9 @@
       }
     },
     "d3plus-format": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3plus-format/-/d3plus-format-1.2.4.tgz",
-      "integrity": "sha512-3KelOUaridcP/G9ii3Faw9sj9FmoqixtWh/PtUWuZ3tJ9sfl52wj7UHnDbfDoFLpcZB3oPg15FDPljocGknhsA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/d3plus-format/-/d3plus-format-1.2.6.tgz",
+      "integrity": "sha512-m/d5cv5uRj3MObj1nZhrTeUxA8gu/IIUoMKVsSbwVJS0qoqm8s1u68JV/oW3aL3j48avASJoDpK0mxSmJjwZtQ==",
       "requires": {
         "d3-format": "^3.1.0",
         "d3-time": "^3.1.0",
@@ -7596,21 +7596,21 @@
       }
     },
     "d3plus-plot": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3plus-plot/-/d3plus-plot-1.2.4.tgz",
-      "integrity": "sha512-VAS+4lwkW01P7O+9Zfp7xESyEQ4WxADvqjWAwCfAQJapx9DIbe8BL6a6xqXwCDMVq8Yr57BzUaC2y1+8i3fJPA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/d3plus-plot/-/d3plus-plot-1.2.7.tgz",
+      "integrity": "sha512-1jfavVBwL3YeMbt48/tO07HIXZC9SuiznzSOKAxEZCuGYWVVvQgK+tRvAkIS6D8qUTmr8pZUwmoMBdJq/uj0QQ==",
       "requires": {
-        "d3-array": "^3.2.3",
+        "d3-array": "^3.2.4",
         "d3-collection": "^1.0.7",
         "d3-scale": "^4.0.2",
         "d3-selection": "^3.0.0",
         "d3-shape": "^3.2.0",
-        "d3plus-axis": "^1.2.8",
+        "d3plus-axis": "^1.2.10",
         "d3plus-color": "^1.1.2",
         "d3plus-common": "^1.2.4",
-        "d3plus-format": "^1.2.4",
+        "d3plus-format": "^1.2.6",
         "d3plus-shape": "^1.1.1",
-        "d3plus-viz": "^1.3.2"
+        "d3plus-viz": "^1.3.4"
       }
     },
     "d3plus-priestley": {
@@ -7672,13 +7672,13 @@
       }
     },
     "d3plus-timeline": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/d3plus-timeline/-/d3plus-timeline-1.1.2.tgz",
-      "integrity": "sha512-VG+pD18QpYDOBLmVJ06RCPg/Bl30xIfMUsiZYIx3BdQftGsDeDavkVIYrNkInwRzKZv1WE4wZVfJD9XKn7dK1g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3plus-timeline/-/d3plus-timeline-1.1.4.tgz",
+      "integrity": "sha512-6l4efJqM96PaJYV3csSQ38mXwz1A7ItAVPwhHs0a6gs/w7zstfyu/TlDi9XVgPML4Yg3Rp+yZ6NVDXgkVtUNhA==",
       "requires": {
         "d3-brush": "^3.0.0",
         "d3-selection": "^3.0.0",
-        "d3plus-axis": "^1.2.8",
+        "d3plus-axis": "^1.2.9",
         "d3plus-color": "^1.1.2",
         "d3plus-common": "^1.2.4",
         "d3plus-format": "^1.2.4"
@@ -7696,24 +7696,24 @@
       }
     },
     "d3plus-viz": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/d3plus-viz/-/d3plus-viz-1.3.3.tgz",
-      "integrity": "sha512-hipd3SwSVwdXmE3hcBDbdogbJzo84kawgeqqXow077tEC0J8ZUCmV5EqBBnuZIYJEIfipAYC3TcfkZuKS1pvWQ==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/d3plus-viz/-/d3plus-viz-1.3.5.tgz",
+      "integrity": "sha512-U5cLkwRre8/4+pcxto+tAGpHpBAp9AH9EVi7+CXJ+Kwq3YYdvH1NU4I21dr7PzlUcy5xB3yd7sfdeUEE+XvuUQ==",
       "requires": {
-        "d3-array": "^3.2.3",
+        "d3-array": "^3.2.4",
         "d3-brush": "^3.0.0",
         "d3-color": "^3.1.0",
         "d3-queue": "^3.0.7",
         "d3-request": "^1.0.6",
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0",
-        "d3plus-axis": "^1.2.5",
+        "d3plus-axis": "^1.2.10",
         "d3plus-color": "^1.1.2",
         "d3plus-common": "^1.2.4",
-        "d3plus-format": "^1.2.4",
+        "d3plus-format": "^1.2.6",
         "d3plus-legend": "^1.2.1",
         "d3plus-text": "^1.2.3",
-        "d3plus-timeline": "^1.1.0",
+        "d3plus-timeline": "^1.1.4",
         "d3plus-tooltip": "^1.1.1",
         "lrucache": "^1.0.3"
       }

--- a/src/toolbox/chartConfigs.js
+++ b/src/toolbox/chartConfigs.js
@@ -26,6 +26,8 @@ export function createChartConfig(chart, uiParams) {
     {
       legend: isEnlarged || isSingleChart,
 
+      timePersist: isEnlarged || isSingleChart,
+
       titlePadding: isEnlarged || isSingleChart,
 
       tooltipConfig: tooltipGenerator(chart, uiParams),

--- a/src/toolbox/chartConfigs.js
+++ b/src/toolbox/chartConfigs.js
@@ -51,6 +51,8 @@ export function createChartConfig(chart, uiParams) {
     userConfig
   );
 
+  if (!isEnlarged && !isSingleChart) config.colorScalePosition = false;
+
   if (
     !includes(["Percentage", "Rate"], measure.annotations.units_of_measurement) &&
     includes(["SUM", "UNKNOWN"], measure.aggregatorType)

--- a/src/toolbox/math.js
+++ b/src/toolbox/math.js
@@ -59,19 +59,6 @@ export function mean(values) {
 }
 
 /**
- * Calculate the Relative Standard Deviation
- * This means it should have a numeric value, and a valid operator.
- * @param {any[]} data An array to check
- * @param {string} measureName Name of the measure
- */
-export function relativeStdDev(data, measureName) {
-  const dataPoints = data.map(d => d[measureName]);
-  return dataPoints.length > 0
-    ? Math.sqrt(variance(dataPoints)) / mean(dataPoints)
-    : NaN;
-}
-
-/**
  * @param {number[]} values
  * @returns {number}
  */

--- a/src/toolbox/title.js
+++ b/src/toolbox/title.js
@@ -101,7 +101,9 @@ export function chartTitleGenerator(chart, uiParams) {
 
   // for charts with a time dimension...
   if (dg.timeDrilldown) {
-    const timeLevelName = dg.timeDrilldown.caption;
+    const timeLevelCaption = dg.timeDrilldown.caption;
+    const timeLevelName = getCaption(dg.timeDrilldown, locale);
+
     const timeLevelId = getColumnId(timeLevelName, dg.dataset);
     // if only one time exists, simply specify period
     if (dg.membersCount[dg.timeDrilldown.caption] === 1) {
@@ -111,7 +113,7 @@ export function chartTitleGenerator(chart, uiParams) {
     else if (chart.isTimeline) {
       // add function to add current period to title (because it should be the only period being shown)
       titleFn = data => {
-        const {minTime, maxTime} = findTimeRange(data, timeLevelId, timeLevelName);
+        const {minTime, maxTime} = findTimeRange(data, timeLevelId, timeLevelCaption);
         return `${title} (${timeLevelName}: ${periodToString(minTime, maxTime !== minTime && maxTime)})`;
       };
     }

--- a/src/toolbox/tooltip.js
+++ b/src/toolbox/tooltip.js
@@ -1,4 +1,4 @@
-import {abbreviateList} from "./strings";
+import {abbreviateList, getCaption} from "./strings";
 
 /**
  * Generates the parameters for the tooltip shown for the current datagroup.
@@ -7,6 +7,7 @@ import {abbreviateList} from "./strings";
  */
 export function tooltipGenerator(chart, {translate: t}) {
   const {dg, measureSet} = chart;
+  const {locale} = dg;
   const {measure, collection, source, moe, uci, lci, formatter} = measureSet;
 
   const measureName = measure.name;
@@ -50,20 +51,20 @@ export function tooltipGenerator(chart, {translate: t}) {
     if (shouldShow.lci && shouldShow.uci) {
       output.push([
         t("chart_labels.ci"),
-        d => `${formatter(d[lciName] * 1 || 0)} - ${formatter(d[uciName] * 1 || 0)}`
+        d => `${formatter(d[lciName] * 1 || 0, locale)} - ${formatter(d[uciName] * 1 || 0, locale)}`
       ]);
     }
     else if (shouldShow.moe) {
       output.push([
         t("chart_labels.moe"),
-        d => `± ${formatter(d[moeName] * 1 || 0)}`
+        d => `± ${formatter(d[moeName] * 1 || 0, locale)}`
       ]);
     }
-  
+
     if (shouldShow.src) {
       output.push([t("chart_labels.source"), d => `${d[sourceName]}`]);
     }
-  
+
     if (shouldShow.clt) {
       output.push([t("chart_labels.collection"), d => `${d[collectionName]}`]);
     }
@@ -71,12 +72,13 @@ export function tooltipGenerator(chart, {translate: t}) {
     // if there is a time drilldown, it will not be included in the drilldown
     // levels and needs to be specified in tooltip body
     if (chart.dg.timeDrilldown) {
-      const timeLvlName = chart.dg.timeDrilldown.caption;
-      output.push([timeLvlName, input[timeLvlName]]);
+      const timeLvlName = getCaption(chart.dg.timeDrilldown, locale);
+      const timeLvlCaption = chart.dg.timeDrilldown.caption;
+      output.push([timeLvlName, input[timeLvlCaption]]);
     }
 
     // add measure value at end
-    output.push([measureName, formatter(input[measureName])]);
+    output.push([getCaption(measure, locale), formatter(input[measureName], locale)]);
 
     return output;
   };


### PR DESCRIPTION
 - updates deep d3plus minor deps for formatting fixes
 - adds locale argument to formatters usage
 - disables timePersist when viz is small
 - hides colorScale when viz is small
 - fixes localization of time in titles
 - fixes localization of tooltip content