### PR TITLE
improves display of small/tiled visualizations

### DIFF
--- a/example/QueryManager.tsx
+++ b/example/QueryManager.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Badge, rem } from "@mantine/core";
+import { ActionIcon, Badge, Flex, rem } from "@mantine/core";
 import { IconEdit } from "@tabler/icons-react";
 import React, { useCallback, useMemo, useState } from "react";
 import { QueryEditor } from "./QueryEditor";
@@ -40,16 +40,10 @@ export const QueryManager = (props: {
   ), [currentQuery, queries]);
 
   return (
-    <div className="query-manager">
-      <div style={{
-        display: "flex",
-        gap: "0.5rem",
-        padding: "0.5rem",
-      }}>
-        <button onClick={createHandler}>New query</button>
-        <button onClick={clearHandler}>Clear</button>
-        {queryPickers}
-      </div>
+    <Flex direction="column" w="100%" gap="sm" className="query-manager">
+      <button onClick={createHandler}>New query</button>
+      {queryPickers}
+      <button onClick={clearHandler}>Clear</button>
       <dialog open={currentEdit != null}>
         <QueryEditor id={currentEdit || ""} onClose={closeHandler} />
       </dialog>
@@ -77,7 +71,7 @@ dialog textarea {
   box-sizing: border-box;
 }
 `}</style>
-    </div>
+    </Flex>
   );
 };
 

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -85,14 +85,19 @@ function Demo() {
   const [result, error] = useQuery(query);
 
   return (
-    <Flex direction="row">
+    <Flex direction="row" h="100vh">
       <Flex direction="column" gap="sm" align="center" p="sm" w={300} miw={300}>
         <Button compact uppercase color="indigo" onClick={setDebugger.toggle}>
           {Vizwrapper.name}
         </Button>
         <QueryManager currentQuery={currentQuery} onChange={setCurrentQuery} />
       </Flex>
-      <div id="viz-scroller" style={{overflowY: "scroll", height: "100vh"}}>
+      <div id="viz-scroller" style={{
+        overflowY: "scroll",
+        flex: "1 0 auto",
+        padding: "0.75rem",
+        boxSizing: "border-box"
+      }}>
         <D3plusContext.Provider value={d3plusConfig}>
           {result && <Vizwrapper
             queries={result}

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -7,6 +7,11 @@ import {useQuery} from "./useQuery";
 import {useQueryParams} from "./useQueryParams";
 import {useDisclosure} from "@mantine/hooks";
 import {Button, Flex} from "@mantine/core";
+import {D3plusContext} from "d3plus-react";
+
+const d3plusConfig = {
+  colorScalePosition: "bottom"
+};
 
 const topojsonArray = [
   {
@@ -80,34 +85,39 @@ function Demo() {
   const [result, error] = useQuery(query);
 
   return (
-    <Flex direction="column">
-      <Flex gap="sm" align="center" px="sm">
+    <Flex direction="row">
+      <Flex direction="column" gap="sm" align="center" p="sm" w={300} miw={300}>
         <Button compact uppercase color="indigo" onClick={setDebugger.toggle}>
           {Vizwrapper.name}
         </Button>
         <QueryManager currentQuery={currentQuery} onChange={setCurrentQuery} />
       </Flex>
-      {result && <Vizwrapper
-        queries={result}
-        downloadFormats={["svg", "png"]}
-        defaultLocale="ar"
-        allowedChartTypes={[
-          "barchart",
-          "barchartyear",
-          "donut",
-          "geomap",
-          "histogram",
-          "lineplot",
-          "pie",
-          "stacked",
-          "treemap"
-        ]}
-        topojsonConfig={topojsonConfig}
-        translations={translations}
-        userConfig={{
-          locale: "ar-SA"
-        }}
-      />}
+      <div id="viz-scroller" style={{overflowY: "scroll", height: "100vh"}}>
+        <D3plusContext.Provider value={d3plusConfig}>
+          {result && <Vizwrapper
+            queries={result}
+            downloadFormats={["svg", "png"]}
+            defaultLocale="ar"
+            allowedChartTypes={[
+              "barchart",
+              "barchartyear",
+              "donut",
+              "geomap",
+              "histogram",
+              "lineplot",
+              "pie",
+              "stacked",
+              "treemap"
+            ]}
+            topojsonConfig={topojsonConfig}
+            translations={translations}
+            userConfig={{
+              locale: "ar-SA",
+              scrollContainer: "#viz-scroller",
+            }}
+          />}
+        </D3plusContext.Provider>
+      </div>
     </Flex>
   );
 }

--- a/example/useOlapSchema.ts
+++ b/example/useOlapSchema.ts
@@ -1,7 +1,7 @@
 import { Client, Cube, TesseractDataSource } from "@datawheel/olap-client";
 import { useEffect, useState } from "react";
 
-const ds = new TesseractDataSource("https://api.datasaudi.datawheel.us/tesseract/");
+const ds = new TesseractDataSource("/tesseract/");
 export const client = new Client(ds);
 
 export function useOlapSchema() {

--- a/src/components/ChartCard.jsx
+++ b/src/components/ChartCard.jsx
@@ -87,7 +87,7 @@ export const ChartCard = props => {
   const ButtonIcon = focused ? IconArrowsMinimize : IconArrowsMaximize;
   const buttonText = focused ? translate("action_close") : translate("action_enlarge");
   const buttonVariant = focused ? "filled" : "light";
-  const height = focused ? "calc(100vh - 3rem)" : isSingleChart ? "75vh" : 375;
+  const height = focused ? "calc(100vh - 3rem)" : isSingleChart ? "75vh" : 300;
 
   return (
     <Box className="vb-chart-card" h={height} w="100%" style={{overflow: "hidden"}}>

--- a/src/components/Vizbuilder.jsx
+++ b/src/components/Vizbuilder.jsx
@@ -5,7 +5,8 @@ import {useCharts} from "../toolbox/useCharts";
 import {TranslationProvider} from "../toolbox/useTranslation";
 import {ChartCard} from "./ChartCard";
 import NonIdealState from "./NonIdealState";
-import {Grid, Modal, Paper} from "@mantine/core";
+import {Grid, Modal, Paper, useMantineTheme} from "@mantine/core";
+import {useMediaQuery} from "@mantine/hooks";
 
 /** @type {React.FC<VizBldr.VizbuilderProps>} */
 export const Vizbuilder = props => {
@@ -18,24 +19,30 @@ export const Vizbuilder = props => {
 
   const isSingleChart = charts.length === 1;
 
+  const theme = useMantineTheme();
+  const screenIsXL = useMediaQuery(`(min-width: ${theme.breakpoints.xl})`);
+  const screenIsLG = useMediaQuery(`(min-width: ${theme.breakpoints.lg})`);
+  const screenIsMD = useMediaQuery(`(min-width: ${theme.breakpoints.md})`);
+
   const content = useMemo(() => {
     const measureConfig = normalizeMeasureConfig(props.measureConfig);
     const filteredCharts = charts
       .filter((d, i) => charts.findIndex(c => c.key === d.key) === i); // removes duplicate charts
 
-    const colProps = filteredCharts.length === 1 ? {span: 12}
-      : filteredCharts.length === 2 ? {lg: 6}
-      : filteredCharts.length === 3 ? {lg: 6, xl: 4}
-      : {lg: 6, xl: 4, xxl: 3};
+    const columns = filteredCharts.length === 1 ? 1
+      : filteredCharts.length === 2 ? screenIsMD ? 2 : 1
+      : filteredCharts.length === 3 ? screenIsLG ? 3 : screenIsMD ? 2 : 1
+      : screenIsXL ? 4 : screenIsLG ? 3 : screenIsMD ? 2 : 1;
 
     if (filteredCharts.length > 0) {
       return (
         <Grid
+          columns={columns}
           w="100%"
           className={cls("vb-charts-wrapper", {unique: filteredCharts.length === 1})}
         >
           {filteredCharts.map(chart =>
-            <Grid.Col key={chart.key} {...colProps}>
+            <Grid.Col key={chart.key} span={1}>
               <Paper shadow="xs">
                 <ChartCard
                   chart={chart}
@@ -58,7 +65,7 @@ export const Vizbuilder = props => {
 
     const Notice = props.nonIdealState || NonIdealState;
     return <Notice />;
-  }, [currentChart, currentPeriod, charts, props.showConfidenceInt]);
+  }, [currentChart, currentPeriod, charts, props.showConfidenceInt, screenIsXL, screenIsLG, screenIsMD]);
 
   const focusContent = useMemo(() => {
     const measureConfig = normalizeMeasureConfig(props.measureConfig);

--- a/src/toolbox/chartConfigs.js
+++ b/src/toolbox/chartConfigs.js
@@ -224,8 +224,8 @@ const makeConfig = {
 
   /**
    */
-  histogram(chart, uiParams) {
-    const config = makeConfig.barchart(chart, uiParams);
+  histogram(chart, uiParams, isEnlarged) {
+    const config = makeConfig.barchart(chart, uiParams, isEnlarged);
     config.groupPadding = 0;
     return config;
   },
@@ -289,17 +289,17 @@ const makeConfig = {
 
   /**
    */
-  pie(chart, uiParams) {
-    return makeConfig.donut(chart, uiParams);
+  pie(chart, uiParams, isEnlarged) {
+    return makeConfig.donut(chart, uiParams, isEnlarged);
   },
 
   /**
    */
-  stacked(chart, uiParams) {
+  stacked(chart, uiParams, isEnlarged) {
     const {levels} = chart;
     const {measure} = chart.measureSet;
 
-    const config = makeConfig.lineplot(chart, uiParams);
+    const config = makeConfig.lineplot(chart, uiParams, isEnlarged);
     config.yConfig = {
       scale: "linear",
       title: getCaption(measure, chart.dg.locale)

--- a/src/toolbox/chartConfigs.js
+++ b/src/toolbox/chartConfigs.js
@@ -57,7 +57,7 @@ export function createChartConfig(chart, uiParams) {
     !includes(["Percentage", "Rate"], measure.annotations.units_of_measurement) &&
     includes(["SUM", "UNKNOWN"], measure.aggregatorType)
   ) {
-    config.total = measureName;
+    config.total = isEnlarged ? measureName : false;
   }
 
   if (timeDrilldown && config.time && chart.isTimeline) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,17 +1,29 @@
 import {defineConfig} from "vite";
 import react from "@vitejs/plugin-react";
 
+/**
+ * Replace the target URL of the backend server in this file
+ * to make vite proxy the requests and avoid CORS issues.
+ */
+const url = new URL("https://api.datasaudi.datawheel.us/tesseract/");
+const headers = {};
+
+// ensure the target URL ends with a trailing slash
+url.pathname = `${url.pathname}/`.replace(/\/{2,}/g, "/");
+
 export default defineConfig({
   plugins: [react()],
   root: "./example/",
   server: {
     proxy: {
-      "/tesseract": {
+      "/tesseract/": {
         // auth: "username:password",
-        target: "https://dev.sebrae.api.datawheel.us/tesseract/",
         changeOrigin: true,
+        followRedirects: true,
+        headers,
+        rewrite: path => path.replace(/^\/tesseract\//, url.pathname),
         secure: false,
-        rewrite: path => path.replace(/^\/tesseract/, "")
+        target: url.origin
       }
     }
   }


### PR DESCRIPTION
This PR aims to improve the display of viz ChartCards when viewed in the scrolling tile list, primarily by removing axis ticks/titles and "total" displays, which I believe cleans up the tile display and I hope will encourage users to enlarge a viz to view its full details and labels. This is needed for a deploy in DataSaudi this upcoming Thursday 🙏🏻 
 - reconfigures default chartConfig to hide axis/ticks when in small tiles
 - hides "total" display when not enlarged
 - fixes Grid column resizing in Vizbuilder
 - decreases default tile height for ChartCard
 - changes example app layout to mimic left/right tesseract-ui
